### PR TITLE
Remove unnecessary logging

### DIFF
--- a/src/mediathek/controller/Log.java
+++ b/src/mediathek/controller/Log.java
@@ -64,40 +64,18 @@ public class Log {
         final long maxMem = rt.maxMemory();
         final long freeMem = rt.freeMemory();
 
-        Log.systemMeldung("");
-        Log.systemMeldung("");
-        Log.systemMeldung("###########################################################");
-        Log.systemMeldung("###########################################################");
-        Log.systemMeldung("Programmstart: " + sdf.format(startZeit));
-        Log.systemMeldung("###########################################################");
-        Log.systemMeldung("###########################################################");
-        Log.systemMeldung("totalMemory: " + totalMem / BYTES_TO_MBYTE + " MiB");
-        Log.systemMeldung("maxMemory: " + maxMem / BYTES_TO_MBYTE + " MiB");
-        Log.systemMeldung("freeMemory: " + freeMem / BYTES_TO_MBYTE + " MiB");
-        Log.systemMeldung("###########################################################");
         //Version
         Log.systemMeldung(Funktionen.getProgVersionString());
-        Log.systemMeldung("Compiled: " + Funktionen.getCompileDate());
-        Log.systemMeldung("###########################################################");
         //dynamically get caller class name...
         final Throwable t = new Throwable();
         final StackTraceElement methodCaller = t.getStackTrace()[2];
         systemMeldung("Classname: " + methodCaller.getClassName());
-
-        String[] java = Funktionen.getJavaVersion();
-        for (final String ja : java) {
-            Log.systemMeldung(ja);
-        }
-        Log.systemMeldung("###########################################################");
     }
 
     public static synchronized void startMeldungen() {
         versionsMeldungen();
         Log.systemMeldung("Programmpfad: " + Funktionen.getPathJar());
         Log.systemMeldung("Verzeichnis Einstellungen: " + Daten.getSettingsDirectory_String());
-        Log.systemMeldung("###########################################################");
-        Log.systemMeldung("");
-        Log.systemMeldung("");
     }
 
     // Fehlermeldung mit Exceptions
@@ -152,25 +130,11 @@ public class Log {
         } catch (Exception ex) {
             minuten = -1;
         }
-        systemMeldung("");
-        systemMeldung("");
-        systemMeldung("###########################################################");
-        systemMeldung("   --> Beginn: " + sdf.format(startZeit));
-        systemMeldung("   --> Fertig: " + sdf.format(stopZeit));
-        systemMeldung("   --> Dauer[Min]: " + (minuten == 0 ? "<1" : minuten));
-        systemMeldung("###########################################################");
-        systemMeldung("");
-        systemMeldung("   und Tschuess");
-        systemMeldung("");
-        systemMeldung("");
-        systemMeldung("###########################################################");
     }
 
     public static ArrayList<String> printFehlerMeldung() {
         ArrayList<String> retList = new ArrayList<>();
 
-        retList.add("");
-        retList.add("###########################################################");
         if (fehlerListe.size() == 0) {
             retList.add(" Keine Fehler :)");
         } else {
@@ -204,8 +168,6 @@ public class Log {
                 }
             }
         }
-        retList.add("###########################################################");
-        retList.add("");
         return retList;
     }
 

--- a/src/mediathek/controller/Log.java
+++ b/src/mediathek/controller/Log.java
@@ -51,7 +51,6 @@ public class Log {
     private static final LinkedList<Integer[]> fehlerListe = new LinkedList<>(); // [Fehlernummer, Anzahl, Exception(0,1 für ja, nein)]
     private static final boolean progress = false;
     private static final String progressText = "";
-    private static final Date startZeit = new Date(System.currentTimeMillis());
     public static PanelMeldungen panelMeldungenFehler = null; // unschön, gab aber sonst einen Deadlock mit notifyMediathekListener
     public static PanelMeldungen panelMeldungenSystem = null;
     public static PanelMeldungen panelMeldungenPlayer = null;
@@ -114,21 +113,9 @@ public class Log {
     }
 
     public static void printEndeMeldung() {
-        systemMeldung("");
-        systemMeldung("");
-        systemMeldung("");
-        systemMeldung("");
         ArrayList<String> ret = printFehlerMeldung();
         for (String s : ret) {
             systemMeldung(s);
-        }
-        // Laufzeit ausgeben
-        final Date stopZeit = new Date(System.currentTimeMillis());
-        int minuten;
-        try {
-            minuten = Math.round((stopZeit.getTime() - startZeit.getTime()) / (1000 * 60));
-        } catch (Exception ex) {
-            minuten = -1;
         }
     }
 

--- a/src/mediathek/tool/Duration.java
+++ b/src/mediathek/tool/Duration.java
@@ -44,11 +44,7 @@ public class Duration {
     public final void start(String text) {
         startZeit = new Date(System.currentTimeMillis());
         if (!text.isEmpty()) {
-            System.out.println("");
-            System.out.println("======================================");
             System.out.println(" Start: " + text);
-            System.out.println("======================================");
-            System.out.println("");
         }
     }
 
@@ -59,10 +55,6 @@ public class Duration {
         } catch (Exception ex) {
             sekunden = -1;
         }
-        System.out.println("");
-        System.out.println("======================================");
         System.out.println(" " + text + " [ms]: " + sekunden);
-        System.out.println("======================================");
-        System.out.println("");
     }
 }


### PR DESCRIPTION
Most logging things are not of interest, not even when debugging MediathekView. Since these lines only go to syslog I doubt someone would appreciate your artistic logging.

As an alternative solution I would recommend to not do any (non-error) logging at all by default. Do the logging only if someone added a specific parameter like `--debug` to MediathekView's command line.