### PR TITLE
Added support for download programs that forward the download action to a remote computer.

### DIFF
--- a/res/bin/aria2-remote.sh
+++ b/res/bin/aria2-remote.sh
@@ -1,11 +1,11 @@
-#!/bin/bash -x
+#!/bin/bash
 
 log=/tmp/MediathekView-aria2.log
 echo "Running $0 $*" >$log
-aria2_url=$1
-aria2_secret=$2
-url=$3
-filename=$(basename "$4")
+url=$1
+filename=$(basename "$2")
+aria2_server_url=$3
+aria2_server_secret=$4
 
 echo "MediathekView-aria2 parameters:" >>$log
 while [ -n "$1" ]

--- a/res/bin/aria2-remote.sh
+++ b/res/bin/aria2-remote.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -x
+
+log=/tmp/MediathekView-aria2.log
+echo "Running $0 $*" >$log
+aria2_url=$1
+aria2_secret=$2
+url=$3
+filename=$(basename "$4")
+
+echo "MediathekView-aria2 parameters:" >>$log
+while [ -n "$1" ]
+do
+  echo "$1" >>$log
+  shift
+done
+
+id=medview
+method=aria2.addUri
+if [ -n "$filename" ]
+then
+  options=",{\"out\":\"${filename}\"}"
+else
+  options=""
+fi
+params="[\"token:${aria2_secret}\",[\"${url}\"]${options}]"
+params_base64enc=$(echo "${params}" | base64 -w 0 -)
+params_base64enc_urlenc=${params_base64enc//=/%3D}
+
+get="${aria2_url}?id=${id}&method=${method}&params=${params_base64enc_urlenc}"
+
+echo "executing: $get" >>$log
+
+result=$(curl -S -k "$get")
+
+echo "result: $result" >>$log
+
+if [[ $result =~ '"result":' ]]
+then
+  exit 0
+else
+  exit 1
+fi
+

--- a/src/mediathek/controller/starter/Start.java
+++ b/src/mediathek/controller/starter/Start.java
@@ -19,6 +19,7 @@
  */
 package mediathek.controller.starter;
 
+import mediathek.daten.DatenDownload;
 import mediathek.tool.MVInputStream;
 import msearch.tool.Datum;
 
@@ -49,9 +50,10 @@ public class Start {
     public Start() {
     }
 
-    public static String getTextProgress(final Start s) {
+    public static String getTextProgress(final DatenDownload download) {
         String ret = "";
-
+        boolean isRemote = download.isRemoteDownload();
+        Start s = download.start;
         if (s == null)
             return ret;
 
@@ -60,22 +62,24 @@ public class Start {
                 break;
 
             case PROGRESS_WARTEN:
-                ret = "warten";
+                ret = isRemote ? "remote" : "warten";
                 break;
 
             case PROGRESS_GESTARTET:
-                ret = "gestartet";
+                ret = isRemote ? "remote:gesendet" : "gestartet";
                 break;
 
             case PROGRESS_FERTIG:
                 if (s.status == Start.STATUS_ERR)
-                    ret = "fehlerhaft";
+                    ret = isRemote ? "remote:fehler" : "fehlerhaft";
                 else
-                    ret = "fertig";
+                    ret = isRemote ? "remote:fertig" : "fertig";
                 break;
 
             default:
-                if (1 < s.percent && s.percent < PROGRESS_FERTIG) {
+            	if (isRemote)
+            		ret = "remote";
+            	else if (1 < s.percent && s.percent < PROGRESS_FERTIG) {
                     double d = s.percent / 10.0;
                     ret = Double.toString(d) + "%";
                 }

--- a/src/mediathek/controller/starter/StarterClass.java
+++ b/src/mediathek/controller/starter/StarterClass.java
@@ -481,7 +481,7 @@ public class StarterClass {
                                 }
                                 break;
                             case stat_restart:
-                                if (!datenDownload.isRestart()) {
+                                if (!datenDownload.isRestart() || datenDownload.isRemoteDownload()) {
                                     // dann wars das
                                     stat = stat_fertig_fehler;
                                 } else {
@@ -521,8 +521,8 @@ public class StarterClass {
                                 }
                                 break;
                             case stat_pruefen:
-                                if (datenDownload.quelle == DatenDownload.QUELLE_BUTTON) {
-                                    //für die direkten Starts mit dem Button wars das dann
+                                if (datenDownload.quelle == DatenDownload.QUELLE_BUTTON || datenDownload.isRemoteDownload()) {
+                                    //für die direkten Starts mit dem Button und die remote downloads wars das dann
                                     stat = stat_fertig_ok;
                                 } else if (pruefen(datenDownload, start)) {
                                     //fertig und OK

--- a/src/mediathek/daten/DatenDownload.java
+++ b/src/mediathek/daten/DatenDownload.java
@@ -134,9 +134,11 @@ public class DatenDownload implements Comparable<DatenDownload> {
     public static final int DOWNLOAD_SUBTITLE_NR = 35;
     public static final String DOWNLOAD_REF = "Ref";
     public static final int DOWNLOAD_REF_NR = 36;
+    public static final String DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD = "Remote-Download";
+    public static final int DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR = 37;
     //
     public static final String DOWNLOAD = "Downlad";
-    public static final int MAX_ELEM = 37;
+    public static final int MAX_ELEM = 38;
     public static final String[] COLUMN_NAMES = {DOWNLOAD_NR, DOWNLOAD_FILM_NR, DOWNLOAD_ABO, DOWNLOAD_SENDER, DOWNLOAD_THEMA, DOWNLOAD_TITEL,
         DOWNLOAD_BUTTON_START, DOWNLOAD_BUTTON_DEL,
         DOWNLOAD_PROGRESS, DOWNLOAD_RESTZEIT, DOWNLOAD_BANDBREITE, DOWNLOAD_GROESSE,
@@ -144,7 +146,7 @@ public class DatenDownload implements Comparable<DatenDownload> {
         DOWNLOAD_FILM_URL, DOWNLOAD_HISTORY_URL, DOWNLOAD_URL, DOWNLOAD_URL_RTMP, DOWNLOAD_URL_SUBTITLE,
         DOWNLOAD_PROGRAMMSET, DOWNLOAD_PROGRAMM, DOWNLOAD_PROGRAMM_AUFRUF, DOWNLOAD_PROGRAMM_AUFRUF_ARRAY, DOWNLOAD_PROGRAMM_RESTART,
         DOWNLOAD_ZIEL_DATEINAME, DOWNLOAD_ZIEL_PFAD, DOWNLOAD_ZIEL_PFAD_DATEINAME, DOWNLOAD_ART, DOWNLOAD_QUELLE,
-        DOWNLOAD_ZURUECKGESTELLT, DOWNLOAD_INFODATEI, DOWNLOAD_SPOTLIGHT, DOWNLOAD_SUBTITLE, DOWNLOAD_REF};
+        DOWNLOAD_ZURUECKGESTELLT, DOWNLOAD_INFODATEI, DOWNLOAD_SPOTLIGHT, DOWNLOAD_SUBTITLE, DOWNLOAD_REF, DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD};
     public static final String[] COLUMN_NAMES_ = {DOWNLOAD_NR, DOWNLOAD_FILM_NR, DOWNLOAD_ABO, DOWNLOAD_SENDER, DOWNLOAD_THEMA, DOWNLOAD_TITEL,
         "Button-Start"/*DOWNLOAD_BUTTON_START*/, "Button-Del"/*DOWNLOAD_BUTTON_DEL*/,
         DOWNLOAD_PROGRESS, DOWNLOAD_RESTZEIT, DOWNLOAD_BANDBREITE, "Groesse"/*DOWNLOAD_GROESSE*/,
@@ -152,7 +154,7 @@ public class DatenDownload implements Comparable<DatenDownload> {
         DOWNLOAD_FILM_URL, DOWNLOAD_HISTORY_URL, DOWNLOAD_URL, DOWNLOAD_URL_RTMP, DOWNLOAD_URL_SUBTITLE,
         DOWNLOAD_PROGRAMMSET, DOWNLOAD_PROGRAMM, DOWNLOAD_PROGRAMM_AUFRUF, DOWNLOAD_PROGRAMM_AUFRUF_ARRAY, DOWNLOAD_PROGRAMM_RESTART,
         DOWNLOAD_ZIEL_DATEINAME, DOWNLOAD_ZIEL_PFAD, DOWNLOAD_ZIEL_PFAD_DATEINAME, DOWNLOAD_ART, DOWNLOAD_QUELLE,
-        DOWNLOAD_ZURUECKGESTELLT, DOWNLOAD_INFODATEI, DOWNLOAD_SPOTLIGHT, DOWNLOAD_SUBTITLE, DOWNLOAD_REF};
+        DOWNLOAD_ZURUECKGESTELLT, DOWNLOAD_INFODATEI, DOWNLOAD_SPOTLIGHT, DOWNLOAD_SUBTITLE, DOWNLOAD_REF, DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD};
     public static boolean[] spaltenAnzeigen = new boolean[MAX_ELEM];
     public String[] arr;
 
@@ -341,6 +343,13 @@ public class DatenDownload implements Comparable<DatenDownload> {
         return Boolean.parseBoolean(arr[DOWNLOAD_PROGRAMM_RESTART_NR]);
     }
 
+    public boolean isRemoteDownload() {
+        if (arr[DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR].equals("")) {
+            return false;
+        }
+        return Boolean.parseBoolean(arr[DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR]);
+    }
+
     public boolean isInfoFile() {
         if (arr[DOWNLOAD_INFODATEI_NR].equals("")) {
             return false;
@@ -450,6 +459,7 @@ public class DatenDownload implements Comparable<DatenDownload> {
             }
 
             arr[DOWNLOAD_PROGRAMM_RESTART_NR] = String.valueOf(programm.isRestart());
+            arr[DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR] = String.valueOf(programm.isRemoteDownload());
             dateinamePfadBauen(pSet, film, abo, nname, ppfad);
             programmaufrufBauen(programm);
         } catch (Exception ex) {

--- a/src/mediathek/daten/DatenProg.java
+++ b/src/mediathek/daten/DatenProg.java
@@ -38,26 +38,30 @@ public class DatenProg {
     public static final int PROGRAMM_SUFFIX_NR = 5;
     public static final String PROGRAMM_RESTART = "Restart";
     public static final int PROGRAMM_RESTART_NR = 6;
-    public static final int MAX_ELEM = 7;
+    public static final String PROGRAMM_REMOTE_DOWNLOAD = "Remote";
+    public static final int PROGRAMM_REMOTE_DOWNLOAD_NR = 7;
+    public static final int MAX_ELEM = 8;
     public static final String[] COLUMN_NAMES = {"Beschreibung", PROGRAMM_ZIEL_DATEINAME, "Programm",
-        "Schalter", "Präfix", PROGRAMM_SUFFIX, PROGRAMM_RESTART};
+        "Schalter", "Präfix", PROGRAMM_SUFFIX, PROGRAMM_RESTART, PROGRAMM_REMOTE_DOWNLOAD};
 
     public static final String[] COLUMN_NAMES_ = {PROGRAMM_NAME, PROGRAMM_ZIEL_DATEINAME, PROGRAMM_PROGRAMMPFAD,
-        PROGRAMM_SCHALTER, PROGRAMM_PRAEFIX, PROGRAMM_SUFFIX, PROGRAMM_RESTART};
+        PROGRAMM_SCHALTER, PROGRAMM_PRAEFIX, PROGRAMM_SUFFIX, PROGRAMM_RESTART, PROGRAMM_REMOTE_DOWNLOAD};
     public static boolean[] spaltenAnzeigen = new boolean[MAX_ELEM];
     public String[] arr;
 
     public DatenProg() {
         makeArr();
         arr[PROGRAMM_RESTART_NR] = Boolean.toString(false);
+        arr[PROGRAMM_REMOTE_DOWNLOAD_NR] = Boolean.toString(false);
     }
 
-    public DatenProg(String name, String programmpfad, String schalter, String restart) {
+    public DatenProg(String name, String programmpfad, String schalter, String restart, String remote) {
         makeArr();
         arr[PROGRAMM_NAME_NR] = name;
         arr[PROGRAMM_PROGRAMMPFAD_NR] = programmpfad;
         arr[PROGRAMM_SCHALTER_NR] = schalter;
         arr[PROGRAMM_RESTART_NR] = restart.equals("") ? Boolean.toString(false) : restart;
+        arr[PROGRAMM_REMOTE_DOWNLOAD_NR] = remote.equals("") ? Boolean.toString(false) : remote;
     }
 
     public DatenProg copy() {
@@ -71,6 +75,13 @@ public class DatenProg {
             return false;
         }
         return Boolean.parseBoolean(arr[PROGRAMM_RESTART_NR]);
+    }
+
+    public boolean isRemoteDownload() {
+        if (arr[PROGRAMM_REMOTE_DOWNLOAD_NR].equals("")) {
+            return false;
+        }
+        return Boolean.parseBoolean(arr[PROGRAMM_REMOTE_DOWNLOAD_NR]);
     }
 
     public boolean urlTesten(String url) {

--- a/src/mediathek/daten/ListeDownloads.java
+++ b/src/mediathek/daten/ListeDownloads.java
@@ -282,6 +282,8 @@ public class ListeDownloads extends LinkedList<DatenDownload> {
                             || i == DatenDownload.DOWNLOAD_SUBTITLE_NR
                             || i == DatenDownload.DOWNLOAD_ZURUECKGESTELLT_NR) {
                         object[i] = "";
+                    } else if (i == DatenDownload.DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR) {
+                    	object[i] = download.isRemoteDownload();
                     } else if (i == DatenDownload.DOWNLOAD_DATUM_NR) {
                         object[i] = download.datumFilm;
                     } else if (i == DatenDownload.DOWNLOAD_RESTZEIT_NR) {
@@ -315,7 +317,7 @@ public class ListeDownloads extends LinkedList<DatenDownload> {
                 }
                 return s;
             } else {
-                return Start.getTextProgress(download.start);
+                return Start.getTextProgress(download);
             }
         } else {
             return "";

--- a/src/mediathek/gui/GuiDownloads.java
+++ b/src/mediathek/gui/GuiDownloads.java
@@ -852,7 +852,7 @@ public class GuiDownloads extends PanelVorlage {
                 datenDownload = (DatenDownload) tabelle.getModel().getValueAt(tabelle.convertRowIndexToModel(row), DatenDownload.DOWNLOAD_REF_NR);
                 if (tabelle.convertColumnIndexToModel(column) == DatenDownload.DOWNLOAD_BUTTON_START_NR) {
                     // filmStartenWiederholenStoppen(boolean alle, boolean starten /* starten/wiederstarten oder stoppen */)
-                    if (datenDownload.start != null) {
+                    if (datenDownload.start != null && !datenDownload.isRemoteDownload()) {
                         if (datenDownload.start.status == Start.STATUS_FERTIG) {
                             filmAbspielen_();
                         } else if (datenDownload.start.status == Start.STATUS_ERR) {

--- a/src/mediathek/gui/dialog/DialogEditDownload.java
+++ b/src/mediathek/gui/dialog/DialogEditDownload.java
@@ -52,6 +52,7 @@ public class DialogEditDownload extends javax.swing.JDialog {
     private final JTextField[] textfeldListe = new JTextField[DatenDownload.MAX_ELEM];
     private final JLabel[] labelListe = new JLabel[DatenDownload.MAX_ELEM];
     private final JCheckBox jCheckBoxRestart = new JCheckBox();
+    private final JCheckBox jCheckBoxRemoteDownload = new JCheckBox();
     private final JCheckBox jCheckBoxUnterbrochen = new JCheckBox();
     private final JCheckBox jCheckBoxInfodatei = new JCheckBox();
     private final JCheckBox jCheckBoxSubtitle = new JCheckBox();
@@ -263,6 +264,16 @@ public class DialogEditDownload extends javax.swing.JDialog {
                 c.weightx = 10;
                 gridbag.setConstraints(jCheckBoxRestart, c);
                 jPanelExtra.add(jCheckBoxRestart);
+            } else if (i == DatenDownload.DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR) {
+                jCheckBoxRemoteDownload.setSelected(datenDownload.isRemoteDownload());
+                // jCheckBoxRestart.addActionListener(new BeobCheckbox());
+                jCheckBoxRemoteDownload.setEnabled(false);
+                gridbag.setConstraints(labelListe[i], c);
+                jPanelExtra.add(labelListe[i]);
+                c.gridx = 1;
+                c.weightx = 10;
+                gridbag.setConstraints(jCheckBoxRemoteDownload, c);
+                jPanelExtra.add(jCheckBoxRemoteDownload);
             } else if (i == DatenDownload.DOWNLOAD_UNTERBROCHEN_NR) {
                 // das macht nur Sinn, wenn der Download unterbrochen ist um "es" auszuschalten
                 // Unterbrechung einschalten macht keinen Sinn
@@ -404,7 +415,7 @@ public class DialogEditDownload extends javax.swing.JDialog {
                 } else if (i == DatenDownload.DOWNLOAD_GROESSE_NR) {
                     textfeldListe[i].setText(datenDownload.mVFilmSize.toString());
                 } else if (i == DatenDownload.DOWNLOAD_PROGRESS_NR) {
-                    textfeldListe[i].setText(Start.getTextProgress(datenDownload.start));
+                    textfeldListe[i].setText(Start.getTextProgress(datenDownload));
                 } else if (i == DatenDownload.DOWNLOAD_RESTZEIT_NR) {
                     textfeldListe[i].setText(datenDownload.getTextRestzeit());
                 } else if (i == DatenDownload.DOWNLOAD_ART_NR) {

--- a/src/mediathek/gui/dialogEinstellungen/PanelPsetLang.java
+++ b/src/mediathek/gui/dialogEinstellungen/PanelPsetLang.java
@@ -141,6 +141,7 @@ public class PanelPsetLang extends PanelVorlage {
         jButtonProgAb.addActionListener(new BeobProgAufAb(false));
         jButtonProgPfad.setEnabled(false);
         jCheckBoxRestart.addActionListener(new BeobProgRestart());
+        jCheckBoxRemoteDownload.addActionListener(new BeobProgRemoteDownload());
         //Pset
         jButtonAbspielen.addActionListener(new ActionListener() {
             @Override
@@ -492,6 +493,7 @@ public class PanelPsetLang extends PanelVorlage {
         for (int i = 0; i < tabelleProgramme.getColumnCount(); ++i) {
             if (i == DatenProg.PROGRAMM_PRAEFIX_NR
                     || i == DatenProg.PROGRAMM_RESTART_NR
+                    || i == DatenProg.PROGRAMM_REMOTE_DOWNLOAD_NR
                     || i == DatenProg.PROGRAMM_SUFFIX_NR) {
                 tabelleProgramme.getColumnModel().getColumn(tabelleProgramme.convertColumnIndexToView(i)).setMinWidth(10);
                 tabelleProgramme.getColumnModel().getColumn(tabelleProgramme.convertColumnIndexToView(i)).setMaxWidth(3000);
@@ -525,6 +527,7 @@ public class PanelPsetLang extends PanelVorlage {
         jTextFieldProgSuffix.setEnabled(row != -1);
         jButtonProgPfad.setEnabled(row != -1);
         jCheckBoxRestart.setEnabled(row != -1);
+        jCheckBoxRemoteDownload.setEnabled(row != -1);
         if (row != -1) {
             DatenProg prog = getPset().getProg(tabelleProgramme.convertRowIndexToModel(row));
             jTextFieldProgPfad.setText(prog.arr[DatenProg.PROGRAMM_PROGRAMMPFAD_NR]);
@@ -535,6 +538,7 @@ public class PanelPsetLang extends PanelVorlage {
             jTextFieldProgPraefix.setText(prog.arr[DatenProg.PROGRAMM_PRAEFIX_NR]);
             jTextFieldProgSuffix.setText(prog.arr[DatenProg.PROGRAMM_SUFFIX_NR]);
             jCheckBoxRestart.setSelected(prog.isRestart());
+            jCheckBoxRemoteDownload.setSelected(prog.isRemoteDownload());
         } else {
             jTextFieldProgPfad.setText("");
             jTextFieldProgSchalter.setText("");
@@ -761,6 +765,7 @@ public class PanelPsetLang extends PanelVorlage {
         jTextFieldProgSuffix = new javax.swing.JTextField();
         jCheckBoxRestart = new javax.swing.JCheckBox();
         javax.swing.JLabel jLabel9 = new javax.swing.JLabel();
+        jCheckBoxRemoteDownload = new javax.swing.JCheckBox();
         jTextFieldProgZielDateiName = new javax.swing.JTextField();
         javax.swing.JPanel jPanel3 = new javax.swing.JPanel();
         jScrollPane3 = new javax.swing.JScrollPane();
@@ -1318,6 +1323,8 @@ public class PanelPsetLang extends PanelVorlage {
 
         jCheckBoxRestart.setText("fehlgeschlagene Downloads wieder starten");
 
+        jCheckBoxRemoteDownload.setText("Remote Download");
+        
         jLabel9.setText("Zieldateiname:");
 
         javax.swing.GroupLayout jPanelProgrammDetailsLayout = new javax.swing.GroupLayout(jPanelProgrammDetails);
@@ -1335,6 +1342,7 @@ public class PanelPsetLang extends PanelVorlage {
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(jPanelProgrammDetailsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(jCheckBoxRestart)
+                            .addComponent(jCheckBoxRemoteDownload)
                             .addComponent(jTextFieldProgSchalter)
                             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanelProgrammDetailsLayout.createSequentialGroup()
                                 .addComponent(jTextFieldProgPfad)
@@ -1384,6 +1392,8 @@ public class PanelPsetLang extends PanelVorlage {
                     .addComponent(jLabel4))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(jCheckBoxRestart)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(jCheckBoxRemoteDownload)
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
@@ -1537,6 +1547,7 @@ public class PanelPsetLang extends PanelVorlage {
     private javax.swing.JCheckBox jCheckBoxInfodatei;
     private javax.swing.JCheckBox jCheckBoxLaenge;
     private javax.swing.JCheckBox jCheckBoxRestart;
+    private javax.swing.JCheckBox jCheckBoxRemoteDownload;
     private javax.swing.JCheckBox jCheckBoxSpeichern;
     private javax.swing.JCheckBox jCheckBoxSpotlight;
     private javax.swing.JCheckBox jCheckBoxSubtitle;
@@ -1580,6 +1591,23 @@ public class PanelPsetLang extends PanelVorlage {
                     DatenProg prog = getPset().getListeProg().get(row);
                     prog.arr[DatenProg.PROGRAMM_RESTART_NR] = Boolean.toString(jCheckBoxRestart.isSelected());
                     tabelleProgramme.getModel().setValueAt(Boolean.toString(jCheckBoxRestart.isSelected()), row, DatenProg.PROGRAMM_RESTART_NR);
+                }
+            }
+
+        }
+    }
+
+    private class BeobProgRemoteDownload implements ActionListener {
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (!stopBeob) {
+                int rows = tabelleProgramme.getSelectedRow();
+                if (rows != -1) {
+                    int row = tabelleProgramme.convertRowIndexToModel(rows);
+                    DatenProg prog = getPset().getListeProg().get(row);
+                    prog.arr[DatenProg.PROGRAMM_REMOTE_DOWNLOAD_NR] = Boolean.toString(jCheckBoxRemoteDownload.isSelected());
+                    tabelleProgramme.getModel().setValueAt(Boolean.toString(jCheckBoxRemoteDownload.isSelected()), row, DatenProg.PROGRAMM_REMOTE_DOWNLOAD_NR);
                 }
             }
 

--- a/src/mediathek/tool/CellRendererDownloads.java
+++ b/src/mediathek/tool/CellRendererDownloads.java
@@ -155,7 +155,7 @@ public class CellRendererDownloads extends DefaultTableCellRenderer {
 
                             return panel;
                         } else {
-                            setText(Start.getTextProgress(datenDownload.start));
+                            setText(Start.getTextProgress(datenDownload));
                         }
                     } else {
                         setText("");
@@ -184,6 +184,16 @@ public class CellRendererDownloads extends DefaultTableCellRenderer {
                         setIcon(nein_12);
                     }
                     break;
+
+                case DatenDownload.DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR:
+                    setHorizontalAlignment(SwingConstants.CENTER);
+                    if (datenDownload.isRemoteDownload()) {
+                        setIcon(ja_16);
+                    } else {
+                        setIcon(nein_12);
+                    }
+                    break;
+
                 case DatenDownload.DOWNLOAD_ART_NR:
                     switch (datenDownload.art) {
                         case DatenDownload.ART_DOWNLOAD:
@@ -311,7 +321,7 @@ public class CellRendererDownloads extends DefaultTableCellRenderer {
     private void handleButtonStartColumn(final DatenDownload datenDownload, final boolean isSelected) {
         setHorizontalAlignment(SwingConstants.CENTER);
         if (isSelected) {
-            if (datenDownload.start != null) {
+            if (datenDownload.start != null && !datenDownload.isRemoteDownload()) {
                 if (datenDownload.start.status == Start.STATUS_FERTIG) {
                     setIcon(film_start_tab);
                     setToolTipText(PLAY_DOWNLOADED_FILM);
@@ -327,7 +337,7 @@ public class CellRendererDownloads extends DefaultTableCellRenderer {
                 setToolTipText(DOWNLOAD_STARTEN);
             }
         } else {
-            if (datenDownload.start != null) {
+            if (datenDownload.start != null && !datenDownload.isRemoteDownload()) {
                 if (datenDownload.start.status == Start.STATUS_FERTIG) {
                     setIcon(film_start_sw_tab);
                     setToolTipText(PLAY_DOWNLOADED_FILM);

--- a/src/mediathek/tool/CellRendererProgramme.java
+++ b/src/mediathek/tool/CellRendererProgramme.java
@@ -48,7 +48,8 @@ public class CellRendererProgramme extends DefaultTableCellRenderer {
                 table, value, isSelected, hasFocus, row, column);
         try {
             int c = table.convertColumnIndexToModel(column);
-            if (c == DatenProg.PROGRAMM_RESTART_NR) {
+            if (c == DatenProg.PROGRAMM_RESTART_NR || c == DatenProg.PROGRAMM_REMOTE_DOWNLOAD_NR) {
+            	setHorizontalAlignment(CENTER);
                 if (getText().equals(Boolean.TRUE.toString())) {
                     setIcon(GetIcon.getProgramIcon("ja_16.png"));
                 } else {

--- a/src/mediathek/tool/MVTable.java
+++ b/src/mediathek/tool/MVTable.java
@@ -571,6 +571,7 @@ public final class MVTable extends JTable {
         } else if (i == DatenDownload.DOWNLOAD_BUTTON_START_NR
                 || i == DatenDownload.DOWNLOAD_BUTTON_DEL_NR
                 || i == DatenDownload.DOWNLOAD_PROGRAMM_RESTART_NR
+                || i == DatenDownload.DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR
                 || i == DatenDownload.DOWNLOAD_UNTERBROCHEN_NR
                 || i == DatenDownload.DOWNLOAD_SPOTLIGHT_NR
                 || i == DatenDownload.DOWNLOAD_SUBTITLE_NR
@@ -659,6 +660,7 @@ public final class MVTable extends JTable {
                 || i == DatenDownload.DOWNLOAD_PROGRAMM_AUFRUF_NR
                 || i == DatenDownload.DOWNLOAD_PROGRAMM_AUFRUF_ARRAY_NR
                 || i == DatenDownload.DOWNLOAD_PROGRAMM_RESTART_NR
+                || i == DatenDownload.DOWNLOAD_PROGRAMM_REMOTE_DOWNLOAD_NR
                 || i == DatenDownload.DOWNLOAD_ZIEL_DATEINAME_NR
                 || i == DatenDownload.DOWNLOAD_ZIEL_PFAD_NR
                 || i == DatenDownload.DOWNLOAD_ART_NR


### PR DESCRIPTION
This way a download manager like aria2 running on some server somewhere on the
network can be directly used by MediathekView to initiate downloads of films.

A Linux bash script was added as an example program to use with this new feature.
It forwards the download request to an aria2 daemon (version 1.19 and above)
secured with a secret token. The program parameters for this bash script must be:

%f ** <URL of aria2 daemon> <secret for aria2 daemon>

The URL is the full URL of the daemon including the port number and path
(i.e. http://somewhere.com:6800/jsonrpc).

The settings page of a program of a program set now has an additional check box
to mark a program as such a remote downloading program. Also, due to the fact
that no local file will be created anymore, the download status and download
start button of the download list had to be modified to act accordingly.